### PR TITLE
Reset before request in order to work around VCert's "unmatched key modulus"

### DIFF
--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -530,48 +530,6 @@ func TestRequestCertificateWithValidHours(t *testing.T) {
 	DoRequestCertificateWithValidHours(t, tpp)
 }
 
-func Test_shouldReset(t *testing.T) {
-	tests := []struct {
-		name     string
-		givenErr error
-		want     bool
-	}{
-		{
-			name:     "nil error",
-			givenErr: nil,
-			want:     false,
-		},
-		{
-			name:     "error is not a 500",
-			givenErr: fmt.Errorf("unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 400 Certificate does not exist."),
-			want:     false,
-		},
-		{
-			name:     "error is a 500 but not WebSDK or Click Retry",
-			givenErr: fmt.Errorf("unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA)., Stage: 500."),
-			want:     false,
-		},
-		{
-			name:     "error is a 500 and is Click Retry",
-			givenErr: fmt.Errorf("unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry., Stage: 500."),
-			want:     true,
-		},
-		{
-			name:     "error is a 500 and is WebSDK",
-			givenErr: fmt.Errorf("unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: WebSDK CertRequest Module Requested Certificate, Stage: 500."),
-			want:     true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := shouldReset(tt.givenErr)
-			if got != tt.want {
-				t.Errorf("shouldReset() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 // The reason we are using a mock HTTP server rather than the live TPP server is
 // because consistently triggering the 500 error in a stage different than 0
 // requires putting a powershell script on the TPP VM or turning the Microsoft
@@ -591,7 +549,6 @@ func TestRetrieveCertificate(t *testing.T) {
 	tests := []struct {
 		name         string
 		mockRetrieve []mockResp
-		mockReset    mockResp
 		givenTimeout time.Duration
 		expectErr    string
 	}{
@@ -630,18 +587,6 @@ func TestRetrieveCertificate(t *testing.T) {
 			expectErr: "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 403 Failed to issue grant: User is not authorized for the requested scope",
 		},
 		{
-			name: "should fail when 'private key'",
-			mockRetrieve: []mockResp{
-				// This specific error message is relied upon by vcert itself as
-				// well as terraform-provider-venafi. So let's make sure we
-				// don't break it. See:
-				// https://github.com/Venafi/terraform-provider-venafi/blob/5374fa5/venafi/resource_venafi_certificate.go#L821
-				{"400 Failed to lookup private key, error: Failed to lookup private key vault id",
-					`{"Error":"Failed to lookup private key, error: Failed to lookup private key vault id"}`},
-			},
-			expectErr: "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 400 Failed to lookup private key, error: Failed to lookup private key vault id",
-		},
-		{
 			name: "should succeed if cert immediately available regardless of the timeout value",
 			mockRetrieve: []mockResp{
 				{"200 OK",
@@ -676,94 +621,19 @@ func TestRetrieveCertificate(t *testing.T) {
 			expectErr: "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA)., Stage: 500.",
 		},
 		{
-			name: "should succeed after resetting the msg WebSDK CertRequest",
+			name: "should fail on msg WebSDK CertRequest",
 			mockRetrieve: []mockResp{
 				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: WebSDK CertRequest Module Requested Certificate, Stage: 500.`,
 					`{"Stage": 500, "Status": "WebSDK CertRequest Module Requested Certificate"}`},
-				{`202 Certificate \VED\Policy\TLS/SSL\aexample.com being processed, Status: Post CSR, Stage: 500.`,
-					`{"Stage": 500, "Status": "Post CSR"}`},
-				{`200 OK`,
-					`{"CertificateData":"` + certData + `","Filename":"bexample.com.cer","Format":"base64"}`},
 			},
-			mockReset:    mockResp{`200 OK`, `{"ProcessingResetCompleted": true}`},
-			givenTimeout: 3 * time.Second,
-		},
-		{
-			name: "should fail after resetting msg WebSDK CertRequest and enrollment fails",
-			mockRetrieve: []mockResp{
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: WebSDK CertRequest Module Requested Certificate, Stage: 500.`,
-					`{"Stage": 500, "Status": "WebSDK CertRequest Module Requested Certificate"}`},
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA)., Stage: 500.`,
-					`{"Stage": 500, "Status": "Post CSR failed with error: Cannot connect to the certificate authority (CA)."}`},
-			},
-			mockReset: mockResp{`200 OK`, `{"ProcessingResetCompleted": true}`},
-			expectErr: "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA)., Stage: 500.",
-		},
-		{
-			name: "should fail if msg WebSDK shows twice in a row",
-			mockRetrieve: []mockResp{
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: WebSDK CertRequest Module Requested Certificate, Stage: 500.`,
-					`{"Stage": 500, "Status": "WebSDK CertRequest Module Requested Certificate"}`},
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: WebSDK CertRequest Module Requested Certificate, Stage: 500.`,
-					`{"Stage": 500, "Status": "WebSDK CertRequest Module Requested Certificate"}`},
-			},
-			mockReset: mockResp{`200 OK`, `{"ProcessingResetCompleted": true}`},
 			expectErr: "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: WebSDK CertRequest Module Requested Certificate, Stage: 500.",
 		},
 		{
-			name: "should fail after resetting msg WebSDK CertRequest when enrollment in progress and timeout is 0",
-			mockRetrieve: []mockResp{
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: WebSDK CertRequest Module Requested Certificate, Stage: 500.`,
-					`{"Stage": 500, "Status": "WebSDK CertRequest Module Requested Certificate"}`},
-				{`202 Certificate \VED\Policy\TLS/SSL\aexample.com being processed, Status: Post CSR, Stage: 500.`,
-					`{"Stage": 500, "Status": "Post CSR"}`},
-			},
-			mockReset: mockResp{`200 OK`, `{"ProcessingResetCompleted": true}`},
-			expectErr: "Issuance is pending. You may try retrieving the certificate later using Pickup ID: \\VED\\Policy\\Test\\bexample.com\n\tStatus: Post CSR",
-		},
-		{
-			name: "should succeed after resetting the msg Click Retry",
+			name: "should fail on msg Click Retry",
 			mockRetrieve: []mockResp{
 				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry., Stage: 500.`,
 					`{"Stage": 500, "Status": "This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry."}`},
-				{`200 OK`,
-					`{"CertificateData":"` + certData + `","Filename":"bexample.com.cer","Format":"base64"}`},
 			},
-			mockReset: mockResp{`200 OK`, `{"ProcessingResetCompleted": true}`},
-		},
-		{
-			name: "should succeed after resetting the msg Click Retry and after waiting",
-			mockRetrieve: []mockResp{
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry., Stage: 500.`,
-					`{"Stage": 500, "Status": "This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry."}`},
-				{`202 Certificate \VED\Policy\TLS/SSL\aexample.com being processed, Status: Post CSR, Stage: 500.`,
-					`{"Stage": 500, "Status": "Post CSR"}`},
-				{`200 OK`,
-					`{"CertificateData":"` + certData + `","Filename":"bexample.com.cer","Format":"base64"}`},
-			},
-			mockReset:    mockResp{`200 OK`, `{"ProcessingResetCompleted": true}`},
-			givenTimeout: 3 * time.Second,
-		},
-		{
-			name: "should fail when reset fails after msg Click Retry",
-			mockRetrieve: []mockResp{
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry., Stage: 500.`,
-					`{"Stage": 500, "Status": "This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry."}`},
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA)., Stage: 500.`,
-					`{"Stage": 500, "Status": "Post CSR failed with error: Cannot connect to the certificate authority (CA)."}`},
-			},
-			mockReset: mockResp{`200 OK`, `{"ProcessingResetCompleted": true}`},
-			expectErr: "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA)., Stage: 500.",
-		},
-		{
-			name: "should fail if msg Click Retry shows twice in a row",
-			mockRetrieve: []mockResp{
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry., Stage: 500.`,
-					`{"Stage": 500, "Status": "This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry."}`},
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry., Stage: 500.`,
-					`{"Stage": 500, "Status": "This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry."}`},
-			},
-			mockReset: mockResp{`200 OK`, `{"ProcessingResetCompleted": true}`},
 			expectErr: "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry., Stage: 500.",
 		},
 		{
@@ -771,11 +641,11 @@ func TestRetrieveCertificate(t *testing.T) {
 			mockRetrieve: []mockResp{
 				{`202 Certificate \VED\Policy\TLS/SSL\aexample.com being processed, Status: Post CSR, Stage: 500.`,
 					`{"Stage": 500, "Status": "Post CSR"}`},
-				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA)., Stage: 500.`,
+				{`500 Certificate \VED\Policy\TLS/SSL\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA), Stage: 500.`,
 					`{"Stage": 500, "Status": "Post CSR failed with error: Cannot connect to the certificate authority (CA)."}`},
 			},
 			givenTimeout: 3 * time.Second,
-			expectErr:    "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA)., Stage: 500.",
+			expectErr:    "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \\VED\\Policy\\TLS/SSL\\aexample.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA), Stage: 500.",
 		},
 		{
 			name: "should fail when timeout too small while waiting for the cert",
@@ -787,8 +657,9 @@ func TestRetrieveCertificate(t *testing.T) {
 			expectErr:    "Operation timed out. You may try retrieving the certificate later using Pickup ID: \\VED\\Policy\\Test\\bexample.com",
 		},
 	}
-	serverWith := func(t *testing.T, mockRetrieve []mockResp, mockReset mockResp) (_ *httptest.Server, retrieveCount, resetCount *int32) {
-		retrieveCount, resetCount = new(int32), new(int32)
+
+	serverWith := func(mockRetrieve []mockResp) (_ *httptest.Server, retrieveCount *int32) {
+		retrieveCount = new(int32)
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case r.URL.Path == "/vedsdk/certificates/retrieve":
@@ -800,40 +671,25 @@ func TestRetrieveCertificate(t *testing.T) {
 				req := certificateRetrieveRequest{}
 				_ = json.NewDecoder(r.Body).Decode(&req)
 				if req.CertificateDN != `\VED\Policy\Test\bexample.com` {
-					t.Errorf("/retrieve: expected CertificateDN to be '%s' but got '%s'", `\VED\Policy\Test\bexample.com`, req.CertificateDN)
+					t.Fatalf("/retrieve: expected CertificateDN to be '%s' but got '%s'", `\VED\Policy\Test\bexample.com`, req.CertificateDN)
 				}
 
 				writeRespWithCustomStatus(w,
 					mockRetrieve[index].status,
 					mockRetrieve[index].body,
 				)
-			case r.URL.Path == "/vedsdk/certificates/reset":
-				atomic.AddInt32(resetCount, 1)
-				if mockReset == (mockResp{}) {
-					t.Errorf("/reset: no call was expected, but got 1 call")
-				}
-				req := certificateResetRequest{}
-				_ = json.NewDecoder(r.Body).Decode(&req)
-				if req.CertificateDN != `\VED\Policy\Test\bexample.com` {
-					t.Errorf("/vedsdk/certificates/reset: expected CertificateDN to be %s but got %s", `\VED\Policy\Test\bexample.com`, req.CertificateDN)
-				}
-				if req.Restart != true {
-					t.Errorf("/vedsdk/certificates/reset: expected Restart to be true but got false")
-				}
-
-				writeRespWithCustomStatus(w, mockReset.status, mockReset.body)
 			default:
 				t.Fatalf("mock http server: unimplemented path " + r.URL.Path)
 			}
 		}))
 		t.Cleanup(server.Close)
-		return server, retrieveCount, resetCount
+		return server, retrieveCount
 	}
 	for _, tt := range tests {
 		tt := tt // Because t.Parallel.
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			server, retrieveCount, resetCount := serverWith(t, tt.mockRetrieve, tt.mockReset)
+			server, retrieveCount := serverWith(tt.mockRetrieve)
 			trusted := x509.NewCertPool()
 			trusted.AddCert(server.Certificate())
 
@@ -844,17 +700,11 @@ func TestRetrieveCertificate(t *testing.T) {
 
 			_, err = tpp.RetrieveCertificate(&certificate.Request{PickupID: `\VED\Policy\Test\bexample.com`, Timeout: tt.givenTimeout})
 			if atomic.LoadInt32(retrieveCount) != int32(len(tt.mockRetrieve)) {
-				t.Errorf("tpp.RetrieveCertificate: expected %d calls to /certificates/retrieve, but got %d", len(tt.mockRetrieve), atomic.LoadInt32(retrieveCount))
-			}
-			if tt.mockReset == (mockResp{}) && atomic.LoadInt32(resetCount) != 0 {
-				t.Errorf("tpp.RetrieveCertificate: expected no call to /certificates/reset, but got %d", atomic.LoadInt32(resetCount))
-			}
-			if tt.mockReset != (mockResp{}) && atomic.LoadInt32(resetCount) != 1 {
-				t.Errorf("tpp.RetrieveCertificate: expected 1 call to /certificates/reset, but got %d", atomic.LoadInt32(resetCount))
+				t.Fatalf("tpp.RetrieveCertificate: expected %d calls to /certificates/retrieve, but got %d", len(tt.mockRetrieve), atomic.LoadInt32(retrieveCount))
 			}
 			if tt.expectErr != "" {
 				if err == nil || err.Error() != tt.expectErr {
-					t.Fatalf("tpp.RetrieveCertificate: \nexpected: %q\ngot:      %q", tt.expectErr, err)
+					t.Fatalf("tpp.RetrieveCertificate: expected err to be %q but got %q", tt.expectErr, err)
 				}
 				return
 			}

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -107,11 +107,6 @@ type certificateRetrieveResponse struct {
 	Stage           int    `json:",omitempty"`
 }
 
-type certificateResetRequest struct {
-	CertificateDN string `json:",omitempty"`
-	Restart       bool   `json:",omitempty"`
-}
-
 type RevocationReason int
 
 // RevocationReasonsMap maps *certificate.RevocationRequest.Reason to TPP-specific webSDK codes
@@ -357,7 +352,6 @@ const (
 	urlResourceCertificateRenew       urlResource = "vedsdk/certificates/renew"
 	urlResourceCertificateRequest     urlResource = "vedsdk/certificates/request"
 	urlResourceCertificateRetrieve    urlResource = "vedsdk/certificates/retrieve"
-	urlResourceCertificateReset       urlResource = "vedsdk/certificates/reset"
 	urlResourceCertificateRevoke      urlResource = "vedsdk/certificates/revoke"
 	urlResourceCertificatesAssociate  urlResource = "vedsdk/certificates/associate"
 	urlResourceCertificatesDissociate urlResource = "vedsdk/certificates/dissociate"


### PR DESCRIPTION
**⚠️ THIS PR WAS NOT MERGED UPSTREAM YET ⚠️**

We found out that https://github.com/Venafi/vcert/issues/273 was causing venafi-enhanced-issuer to show the error:

```
vcert error: your data contains problems: request doesn't match certificate: unmatched key modulus
```

We found that it was caused by running `request` and `reset(restart=true)` back to back.

To work around this issue, we decided to unconditionally reset any prior failed enrollment with `reset(restart=false)` so that we don't get stuck with "Fix any errors, and then click Retry." (60% of the time) or "WebSDK CertRequest" (40% of the time), and to revert the changes made in https://github.com/Venafi/vcert/pull/269.

For context, we compared two approaches: (1) unconditionally reset, and (2) conditionally reset synchronously.

## Unconditionally Reset (this PR)

We will go with this solution as an "intermediate" solution.

Instead of conditionally resetting, we always reset. Since we don’t reset and retrieve back to back, we avoid the race condition that was found in https://github.com/Venafi/vcert/pull/273.

```go
reset(restart=false)
request
loop {
    retrieve
    if err, return the error.
    if 200, return the cert.
    if 202, continue.
}
```

I stress-tested TPP to calculate the impact of `reset(restart=false)` under load. The VM was on GCP, I used TPP 23.1 with ExpressSQL, a pd-balanced disk, 4 vCPUs, 16 GB memory.

- **Scenario 1**: I ran `request; retrieve_every_second` 1000 times in parallel = 1 min 57 sec
- **Scenario 2**: I ran `reset(restart=false); request; retrieve_every_second` 1000 times in parallel = 2 min 11 sec

The slow down is 9%.

## Conditionally Reset Synchronously

Dmitry Philimonov suggested that we use `WorkToDoTimeout` to prevent the constant polling. And since we don’t reset and retrieve back to back, we avoid the race condition that was found in https://github.com/Venafi/vcert/pull/273.

```go
loop {
    request(work_todo_timeout=60)
    if 500 and "Fix any errors, and then click Retry" {
        reset(restart=false)
        continue
    }
    if other error, return error.
    if 200, return cert.
}

```

This solution will have to be implemented outside of RetrieveCertificate and RequestCertificate, which means users of the Go SDK will need to change the way they are using the library.

For example:

```go
for {
    cert, err := connector.RequestCertificate(vcert.Request{WorkToDoTimeout: 60 * time.Second})
    if vcert.ErrIsClickToRetry(err) {
        err = connector.ResetCertificate(vcert.Request{WorkToDoTimeout: 0, Restart: false})
        if err != nil {
            return err
        }
        continue
    }
    if err != nil {
        return err
    }
    return cert
}
```
